### PR TITLE
Fix issues with files generation

### DIFF
--- a/custom_components/readme/__init__.py
+++ b/custom_components/readme/__init__.py
@@ -184,7 +184,7 @@ def get_hacs_components():
             "name": get_repository_name(repo),
             "documentation": f"https://github.com/{repo.data.full_name}",
         }
-        for repo in hacs.repositories or []
+        for repo in hacs.repositories or [] if repo.data.installed
     ]
 
 

--- a/custom_components/readme/__init__.py
+++ b/custom_components/readme/__init__.py
@@ -131,7 +131,7 @@ async def write_file(
     def write():
         with open(hass.config.path(path), "w") as open_file:
             if as_yaml:
-                yaml.dump(content, open_file, default_flow_style=False)
+                yaml.dump(content, open_file, default_flow_style=False, allow_unicode=True)
             else:
                 open_file.write(content)
 

--- a/custom_components/readme/__init__.py
+++ b/custom_components/readme/__init__.py
@@ -99,7 +99,7 @@ async def convert_lovelace(hass: HomeAssistant):
     """Convert the lovelace configuration."""
     if os.path.exists(hass.config.path(".storage/lovelace")):
         content = (
-            json.loads(read_file(hass, ".storage/lovelace") or {})
+            json.loads(await read_file(hass, ".storage/lovelace") or {})
             .get("data", {})
             .get("config", {})
         )
@@ -147,7 +147,7 @@ async def add_services(hass: HomeAssistant):
         if hass.data[DOMAIN_DATA].get("convert") or hass.data[DOMAIN_DATA].get(
             "convert_lovelace"
         ):
-            convert_lovelace(hass)
+            await convert_lovelace(hass)
 
         custom_components = await get_custom_integrations(hass)
         hacs_components = get_hacs_components()


### PR DESCRIPTION
On Home Assistant 2021.12.8 multiple changes were needed to make this plugin work.

1) Some await were missing, so `ui-lovelace.yaml` cannot be generated at all
2) When lovelace dashboard config in the UI contains utf-8 characters, there are wrongly encoded in the created `ui-lovelace.yaml` file
3) `hacs_components` variable contains all available components, even though documentation says that it should contain only installed ones:
    > `hacs_components` | Gives you a list of information about HACS installed integrations, plugins, and themes

This PR contains fixes for all those issues. It has been tested on the Home Assistant 2021.12.8.