### PR TITLE
Remove dependency to get_hacs() method, which was removed in hacs 0.19.0

### DIFF
--- a/custom_components/readme/__init__.py
+++ b/custom_components/readme/__init__.py
@@ -15,7 +15,6 @@ from typing import Any, List
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 import yaml
-from custom_components.hacs.const import DOMAIN as HACS_DOMAIN
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.template import AllStates
@@ -173,7 +172,8 @@ async def add_services(hass: HomeAssistant):
 
 
 def get_hacs_components(hass: HomeAssistant):
-    hacs = hass.data.get(HACS_DOMAIN)
+    if (hacs := hass.data.get("hacs")) is None:
+        return []
 
     return [
         {
@@ -181,7 +181,7 @@ def get_hacs_components(hass: HomeAssistant):
             "name": get_repository_name(repo),
             "documentation": f"https://github.com/{repo.data.full_name}",
         }
-        for repo in hacs.repositories.list_downloaded or [] if repo.data.installed
+        for repo in hacs.repositories.list_downloaded or []
     ]
 
 

--- a/hacs.json
+++ b/hacs.json
@@ -5,5 +5,6 @@
   "filename": "readme.zip",
   "homeassistant": "2021.5.0",
   "hide_default_branch": true,
-  "render_readme": true
+  "render_readme": true,
+  "hacs": "0.19.1"
 }


### PR DESCRIPTION
In HACS 0.19.0 the `get_hacs()` method was removed by [#2381](https://github.com/hacs/integration/pull/2381), so this plugin stopped working properly - the list of hacs components was always empty.

This PR fixes the issue. It was tested on Home Assistant 2021.12.8, HACS 0.19.0.