### PR TITLE
[NEW FEATURE] Add addons to available variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,18 +11,24 @@
 [![Discord][discord-shield]][discord]
 [![Community Forum][forum-shield]][forum]
 
-_Use Jinja and data from Home Assistant to generate your README.md file_
+_Use Jinja and data from Home Assistant to generate your README.md file 
+with the list of all your installed add-ons and custom components_
 
 
 ## Installation
 
-1. Using the tool of choice open the directory (folder) for your HA configuration (where you find `configuration.yaml`).
-2. If you do not have a `custom_components` directory (folder) there, you need to create it.
-3. In the `custom_components` directory (folder) create a new folder called `readme`.
-4. Download _all_ the files from the `custom_components/readme/` directory (folder) in this repository.
-5. Place the files you downloaded in the new directory (folder) you created.
-6. Restart Home Assistant
-7. Choose:
+1. Install it with HACS
+
+OR 
+
+1. Install it manually
+   1. Using the tool of choice open the directory (folder) for your HA configuration (where you find `configuration.yaml`).
+   2. If you do not have a `custom_components` directory (folder) there, you need to create it.
+   3. In the `custom_components` directory (folder) create a new folder called `readme`.
+   4. Download _all_ the files from the `custom_components/readme/` directory (folder) in this repository.
+   5. Place the files you downloaded in the new directory (folder) you created.
+2. Restart Home Assistant
+3. Choose:
    - Add `readme:` to your HA configuration.
    - In the HA UI go to "Configuration" -> "Integrations" click "+" and search for "Generate readme"
 
@@ -72,6 +78,9 @@ Variable | Description
 `states` | This is the same as with the rest of Home Assistant.
 `custom_components` | Gives you a list of information about your custom_integrations
 `hacs_components` | Gives you a list of information about HACS installed integrations, plugins, and themes
+`addons` | List of installed Home Assistant Add-ons 
+
+### custom_components
 
 The information about custom integrations are fetched from the integrations manifest.json file, the folowing keys are available:
 
@@ -80,14 +89,6 @@ The information about custom integrations are fetched from the integrations mani
 - `documentation`
 - `codeowners`
 - `version`
-
-The information about integrations tracked with HACS are fetched from the storage hacs files, the folowing keys are available:
-
-- `category`
-- `name`
-- `documentation`
-- `authors`
-- `description`
 
 **Example usage of the  `custom_components` variable:**
 
@@ -100,6 +101,16 @@ _{{custom_component_descriptions[integration.domain]}}_
 {% endif -%}
 {% endfor -%}
 ```
+
+### hacs_components
+
+The information about integrations tracked with HACS are fetched from the storage hacs files, the folowing keys are available:
+
+- `category`
+- `name`
+- `documentation`
+- `authors`
+- `description`
 
 **Example usage of the  `hacs_components` variable:**
 
@@ -119,6 +130,29 @@ _{{custom_component_descriptions[integration.domain]}}_
 - [{{component.name}}]({{component.documentation}})
 {%- endfor %}
 ```
+
+### addons
+
+The following keys are available:
+
+- `name`
+- `slug`
+- `description`
+- `state`
+- `version`
+- `version_latest`
+- `update_available`
+- `repository`
+
+**Example usage:**
+```
+## Add-ons
+{%- for addon in addons | sort(attribute='name') %}
+- {{addon.name}} ({{addon.version}}) - {{addon.description}}
+{%- endfor %}
+```
+
+## Others
 
 **Example usage for documenting Alexa smart home utterances**
 ```
@@ -174,14 +208,6 @@ _"Alexa, turn off the `DEVICE NAME`."_
 {%- endif %}
 {%- endfor %}
 {%- endfor %}
-```
-
-If you only use this integration the output of that will be:
-
-```
-### [Generate readme](https://github.com/custom-components/readme)
-
-_Generates this awesome readme file._
 ```
 
 ## Contributions are welcome!

--- a/README.md
+++ b/README.md
@@ -17,16 +17,7 @@ with the list of all your installed add-ons and custom components_
 
 ## Installation
 
-1. Install it with HACS
-
-OR 
-
-1. Install it manually
-   1. Using the tool of choice open the directory (folder) for your HA configuration (where you find `configuration.yaml`).
-   2. If you do not have a `custom_components` directory (folder) there, you need to create it.
-   3. In the `custom_components` directory (folder) create a new folder called `readme`.
-   4. Download _all_ the files from the `custom_components/readme/` directory (folder) in this repository.
-   5. Place the files you downloaded in the new directory (folder) you created.
+1. Download it with HACS
 2. Restart Home Assistant
 3. Choose:
    - Add `readme:` to your HA configuration.
@@ -71,7 +62,7 @@ When you are happy with how the template look, run the service `readme.generate`
 
 ## Usable variables
 
-In addition to all [Jijna magic you can do](https://jinja.palletsprojects.com/en/2.10.x/templates/), there is also some additional variables you can use in the templates.
+In addition to all [Jinja magic you can do](https://jinja.palletsprojects.com/en/2.10.x/templates/), there is also some additional variables you can use in the templates.
 
 Variable | Description
 -- | --
@@ -131,7 +122,8 @@ The information about integrations tracked with HACS are fetched from the storag
 {%- endfor %}
 ```
 
-### addons
+### Add-ons
+
 
 The following keys are available:
 

--- a/custom_components/readme/__init__.py
+++ b/custom_components/readme/__init__.py
@@ -15,7 +15,6 @@ from typing import Any, List
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 import yaml
-from custom_components.hacs.const import DOMAIN as HACS_DOMAIN
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.template import AllStates
@@ -173,7 +172,8 @@ async def add_services(hass: HomeAssistant):
 
 
 def get_hacs_components(hass: HomeAssistant):
-    hacs = hass.data.get(HACS_DOMAIN)
+    if (hacs := hass.data.get("hacs")) is None:
+        return []
 
     return [
         {
@@ -181,7 +181,7 @@ def get_hacs_components(hass: HomeAssistant):
             "name": get_repository_name(repo),
             "documentation": f"https://github.com/{repo.data.full_name}",
         }
-        for repo in hacs.repositories.list_downloaded or [] if repo.data.installed
+        for repo in hacs.repositories.list_downloaded or []
     ]
 
 

--- a/custom_components/readme/__init__.py
+++ b/custom_components/readme/__init__.py
@@ -10,7 +10,7 @@ import asyncio
 import json
 import os
 from shutil import copyfile
-from typing import Any, List
+from typing import Any, List, Dict
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
@@ -152,11 +152,13 @@ async def add_services(hass: HomeAssistant):
 
         custom_components = await get_custom_integrations(hass)
         hacs_components = get_hacs_components(hass)
+        installed_addons = get_ha_installed_addons(hass)
 
         variables = {
             "custom_components": custom_components,
             "states": AllStates(hass),
             "hacs_components": hacs_components,
+            "addons": installed_addons,
         }
 
         content = await read_file(hass, "templates/README.j2")
@@ -183,6 +185,15 @@ def get_hacs_components(hass: HomeAssistant):
         }
         for repo in hacs.repositories.list_downloaded or []
     ]
+
+
+def get_ha_installed_addons(hass: HomeAssistant) -> List[Dict[str, Any]]:
+    supervisor_info = hass.components.hassio.get_supervisor_info()
+
+    if supervisor_info:
+        return supervisor_info.get("addons", [])
+    else:
+        return []
 
 
 def get_repository_name(repository) -> str:

--- a/custom_components/readme/__init__.py
+++ b/custom_components/readme/__init__.py
@@ -10,13 +10,13 @@ import asyncio
 import json
 import os
 from shutil import copyfile
-from typing import Any, List, Dict
+from typing import Any, Dict, List
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 import yaml
 from homeassistant import config_entries
-from homeassistant.core import HomeAssistant
+from homeassistant.core import callback, HomeAssistant
 from homeassistant.helpers.template import AllStates
 from homeassistant.loader import Integration, IntegrationNotFound, async_get_integration
 from homeassistant.setup import async_get_loaded_integrations
@@ -187,13 +187,15 @@ def get_hacs_components(hass: HomeAssistant):
     ]
 
 
+@callback
 def get_ha_installed_addons(hass: HomeAssistant) -> List[Dict[str, Any]]:
+    if not hass.components.hassio.is_hassio():
+        return []
     supervisor_info = hass.components.hassio.get_supervisor_info()
 
     if supervisor_info:
         return supervisor_info.get("addons", [])
-    else:
-        return []
+    return []
 
 
 def get_repository_name(repository) -> str:

--- a/custom_components/readme/default.j2
+++ b/custom_components/readme/default.j2
@@ -17,17 +17,17 @@ Number of sensors | {{states.sensor | count}}
 - {{addon.name}}
 {%- endfor %}
 
-### HACS Integrations (custom_components)
+### Custom integrations
 {%- for component in hacs_components | selectattr('category', 'equalto', 'integration') | sort(attribute='name') %}
 - [{{component.name}}]({{component.documentation}})
 {%- endfor %}
 
-### HACS Frontend - Plugins
+### Lovelace plugins
 {%- for component in hacs_components | selectattr('category', 'equalto', 'plugin') | sort(attribute='name') %}
 - [{{component.name}}]({{component.documentation}})
 {%- endfor %}
 
-### HACS Frontend - Themes
+### Themes
 {%- for component in hacs_components | selectattr('category', 'equalto', 'theme') | sort(attribute='name') %}
 - [{{component.name}}]({{component.documentation}})
 {%- endfor %}

--- a/custom_components/readme/default.j2
+++ b/custom_components/readme/default.j2
@@ -1,4 +1,3 @@
-{%- set custom_component_descriptions = {"readme": "Generates this awesome readme file."} -%}
 # Welcome !
 
 This is my Home Assistant installation.
@@ -11,15 +10,28 @@ Number of entities | {{states | count}}
 Number of sensors | {{states.sensor | count}}
 
 
-{% if custom_components %}
-## The custom_components that I use
-{% for integration in custom_components %}
-### [{{integration.name}}]({{integration.documentation}})
-{% if integration.domain in custom_component_descriptions %}
-_{{custom_component_descriptions[integration.domain]}}_
-{% endif -%}
-{% endfor -%}
-{% endif %}
+## My installed extensions:
+
+### Add-ons
+{%- for addon in addons | sort(attribute='name') %}
+- {{addon.name}}
+{%- endfor %}
+
+### HACS Integrations (custom_components)
+{%- for component in hacs_components | selectattr('category', 'equalto', 'integration') | sort(attribute='name') %}
+- [{{component.name}}]({{component.documentation}})
+{%- endfor %}
+
+### HACS Frontend - Plugins
+{%- for component in hacs_components | selectattr('category', 'equalto', 'plugin') | sort(attribute='name') %}
+- [{{component.name}}]({{component.documentation}})
+{%- endfor %}
+
+### HACS Frontend - Themes
+{%- for component in hacs_components | selectattr('category', 'equalto', 'theme') | sort(attribute='name') %}
+- [{{component.name}}]({{component.documentation}})
+{%- endfor %}
+
 
 ***
 

--- a/hacs.json
+++ b/hacs.json
@@ -5,5 +5,6 @@
   "filename": "readme.zip",
   "homeassistant": "2021.5.0",
   "hide_default_branch": true,
-  "render_readme": true
+  "render_readme": true,
+  "hacs": "0.19.1"
 }


### PR DESCRIPTION
I think it will be beneficial to add to this component a possibility to list not only HACS components, but Home Assistant add-ons also. That way it will be possible for a user of the plugin to have a list of all extensions (HACS Integrations, plugins, themes and Home Assistant Add-ons) in one place, for example as a part of the documentation for Home Assistant configuration (this is how I am using it).

In this PR I updated README and the default template as well, so it will be more clear for others, what are the capabilities of this component.

Tested on Home Assistant 2021.12.8, HACS 0.19.2.