### PR TITLE
fix: allow reading addons list for hassio installations only

### DIFF
--- a/custom_components/readme/__init__.py
+++ b/custom_components/readme/__init__.py
@@ -11,7 +11,7 @@ import asyncio
 import json
 import os
 from shutil import copyfile
-from typing import Any, Dict, List
+from typing import Any
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
@@ -198,7 +198,7 @@ def get_hacs_components(hass: HomeAssistant):
 
 @callback
 def get_ha_installed_addons(hass: HomeAssistant) -> list[dict[str, Any]]:
-    if is_hassio(hass):
+    if not is_hassio(hass):
         return []
     supervisor_info = get_supervisor_info(hass)
 


### PR DESCRIPTION
Hassio (along with supervised) is the only HA installation type that support add-ons.
The condition had a bug that made the code return an empty list for all hassio installations, which is not correct.

With this fix we can ensure we look for installed add-ons for hassio installations only